### PR TITLE
Make capstone a full dependency; add DEBUG test; avoid CUDA if no `__cuda` present

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/tinygrad-feedst
 
 Home: https://github.com/tinygrad/tinygrad
 
-Package license: MIT
+Package license: MIT AND BSD-3-Clause
 
 Summary: You like pytorch? You like micrograd? You love tinygrad! ❤️
 

--- a/recipe/applegpu_LICENSE
+++ b/recipe/applegpu_LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2021, Dougall Johnson
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipe/patches/0001-point-to-our-own-llvmdev.patch
+++ b/recipe/patches/0001-point-to-our-own-llvmdev.patch
@@ -1,7 +1,7 @@
 From 2bab781a97d7fe18d2566377a64e07a3e1269f71 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Mon, 27 Oct 2025 15:37:17 +0100
-Subject: [PATCH 1/3] point to our own llvmdev
+Subject: [PATCH 1/4] point to our own llvmdev
 
 ---
  tinygrad/runtime/support/llvm.py | 26 ++++++++++++++++++--------

--- a/recipe/patches/0002-move-frontend-dir-to-nn-pr-12470.patch
+++ b/recipe/patches/0002-move-frontend-dir-to-nn-pr-12470.patch
@@ -1,7 +1,7 @@
 From 113ebaeb3ee45c6f93e809c869adb3837ab83313 Mon Sep 17 00:00:00 2001
 From: George Hotz <72895+geohot@users.noreply.github.com>
 Date: Tue, 7 Oct 2025 10:42:22 +0800
-Subject: [PATCH 2/3] move frontend dir to nn [pr] (#12470)
+Subject: [PATCH 2/4] move frontend dir to nn [pr] (#12470)
 
 ---
  examples/benchmark_onnx.py                    | 2 +-

--- a/recipe/patches/0003-update-accuracy-for-every-step-in-beautiful_mnist.py.patch
+++ b/recipe/patches/0003-update-accuracy-for-every-step-in-beautiful_mnist.py.patch
@@ -1,7 +1,7 @@
 From 4ff0ff5eab2aa2eebd9bc7628eb63a26b094f495 Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 17 Dec 2025 22:59:20 +1100
-Subject: [PATCH 3/3] update accuracy for every step in beautiful_mnist.py
+Subject: [PATCH 3/4] update accuracy for every step in beautiful_mnist.py
 
 ---
  examples/beautiful_mnist.py | 2 +-

--- a/recipe/patches/0004-make-apple-disassembler-runnable-when-installed.patch
+++ b/recipe/patches/0004-make-apple-disassembler-runnable-when-installed.patch
@@ -1,0 +1,30 @@
+From 108abaf90efd789f72a2281d26298da831eba3cb Mon Sep 17 00:00:00 2001
+From: "H. Vetinari" <h.vetinari@gmx.com>
+Date: Sun, 4 Jan 2026 17:02:07 +1100
+Subject: [PATCH 4/4] make apple disassembler runnable when installed
+
+upstream has both `<repo_root>/extra/disassemblers` and `<repo_root>/tinygrad/extra/disassemblers/`, c.f.
+https://github.com/tinygrad/tinygrad/blob/v0.11.0/.github/workflows/benchmark.yml#L42
+
+When installed into site-packages, we're calling from
+$SP_DIR/tinygrad/runtime/ops_metal.py
+and want to go to
+$SP_DIR/tinygrad/extra/...
+so reflect that in the folder-hierarchy traversal.
+---
+ tinygrad/runtime/ops_metal.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tinygrad/runtime/ops_metal.py b/tinygrad/runtime/ops_metal.py
+index 9e453eb72..d78e02502 100644
+--- a/tinygrad/runtime/ops_metal.py
++++ b/tinygrad/runtime/ops_metal.py
+@@ -144,7 +144,7 @@ class MetalCompiler(Compiler):
+     with tempfile.NamedTemporaryFile(delete=True) as shader:
+       shader.write(lib)
+       shader.flush()
+-      proc = subprocess.Popen(f"cd {pathlib.Path(__file__).parents[2]}/extra/disassemblers/applegpu && python3 compiler_explorer.py {shader.name}",
++      proc = subprocess.Popen(f"cd {pathlib.Path(__file__).parents[1]}/extra/disassemblers/applegpu && python3 compiler_explorer.py {shader.name}",
+                               stdout=subprocess.PIPE, shell=True, text=True, bufsize=1)
+       for line in unwrap(proc.stdout): print(line, end="")
+       ret = proc.wait()

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,6 +17,8 @@ source:
       - patches/0002-move-frontend-dir-to-nn-pr-12470.patch
       # see more clearly what's happening in mnist test
       - patches/0003-update-accuracy-for-every-step-in-beautiful_mnist.py.patch
+      # ensure we find vendored applegpu
+      - patches/0004-make-apple-disassembler-runnable-when-installed.patch
   - if: osx
     then:
       - target_directory: tinygrad/extra/disassemblers/applegpu
@@ -31,7 +33,12 @@ outputs:
   - package:
       name: tinygrad
     build:
-      script: python -m pip install . -vv
+      script:
+        - python -m pip install . -vv
+        - if: osx
+          then:
+            - mkdir -p $SP_DIR/tinygrad/extra/disassemblers/applegpu
+            - cp -R ./tinygrad/extra/disassemblers/applegpu/* $SP_DIR/tinygrad/extra/disassemblers/applegpu
     requirements:
       build:
         - if: build_platform != host_platform

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -52,6 +52,7 @@ outputs:
         - clang
         - if: cuda_compiler_version != "None"
           then:
+            - __cuda
             - cuda-nvcc_${{ target_platform }}
             - if: linux
               then:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -61,6 +61,30 @@ outputs:
             - tinygrad
             - tinygrad.runtime.autogen.llvm
           pip_check: true
+      # integration-test in addition to test suite below
+      - files:
+          source:
+            - examples/beautiful_mnist.py
+        script:
+          # reduce number of steps; we just need to show that it's functional
+          # however, accuracy should at least trend in the right direction
+          - if: unix
+            then:
+              - export STEPS=25
+              - export TARGET_EVAL_ACC_PCT=90
+            else:
+              - set "STEPS=25"
+              - set "TARGET_EVAL_ACC_PCT=90"
+          - if: aarch64
+            then:
+              # reduce number of steps in emulation
+              - export STEPS=3
+              - export TARGET_EVAL_ACC_PCT=30
+          - if: osx
+            then:
+              # loss decreases as expected, but accuracy appears to be mis-computed
+              - unset TARGET_EVAL_ACC_PCT
+          - python ./examples/beautiful_mnist.py
 
   - package:
       name: tinygrad-tests
@@ -167,32 +191,6 @@ outputs:
             - if: unix and build_platform == target_platform
               then:
                 - 'sys.exit(pytest.main(["-v", "test/", "-k", f"not ({tests_to_skip})", "--durations=50"]))'
-
-      # simpler test that only runs one example;
-      # windows cannot run test suite yet due to lack of jax, minimal test on aarch due to emulation
-      - files:
-          source:
-            - examples/beautiful_mnist.py
-        script:
-          # reduce number of steps; we just need to show that it's functional
-          # however, accuracy should at least trend in the right direction
-          - if: unix
-            then:
-              - export STEPS=25
-              - export TARGET_EVAL_ACC_PCT=90
-            else:
-              - set "STEPS=25"
-              - set "TARGET_EVAL_ACC_PCT=90"
-          - if: aarch64
-            then:
-              # reduce number of steps in emulation
-              - export STEPS=3
-              - export TARGET_EVAL_ACC_PCT=30
-          - if: osx
-            then:
-              # loss decreases as expected, but accuracy appears to be mis-computed
-              - unset TARGET_EVAL_ACC_PCT
-          - python ./examples/beautiful_mnist.py
 
 about:
   homepage: https://github.com/tinygrad/tinygrad

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   version: "0.11.0"
-  build_number: 0
+  build_number: 1
   # see github.com/conda-forge/conda-forge.github.io/issues/1059 for naming discussion
   proc_type: ${{ "cuda" ~ cuda_compiler_version | version_to_buildstring if cuda_compiler_version != "None" else "cpu" }}
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -95,11 +95,11 @@ outputs:
           # run again with high DEBUG value; exercises different paths, e.g. needs capstone
           - if: unix
             then:
-              - export STEPS=2
+              - export STEPS=1
               - export DEBUG=10
               - unset TARGET_EVAL_ACC_PCT
             else:
-              - set "SETPS=2"
+              - set "SETPS=1"
               - set "DEBUG=10"
               - set "TARGET_EVAL_ACC_PCT="
           - if: not aarch64

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -172,7 +172,7 @@ outputs:
       # windows cannot run test suite yet due to lack of jax, minimal test on aarch due to emulation
       - files:
           source:
-            - examples/
+            - examples/beautiful_mnist.py
         script:
           # reduce number of steps; we just need to show that it's functional
           # however, accuracy should at least trend in the right direction

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -78,6 +78,11 @@ outputs:
             - if: linux
               then:
                 - triton
+      run_constraints:
+        - if: win
+          then:
+            # avoid pulling in old MSVC activation
+            - vs2019_win-64 <0.0a0
     tests:
       - python:
           imports:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -86,6 +86,19 @@ outputs:
               # loss decreases as expected, but accuracy appears to be mis-computed
               - unset TARGET_EVAL_ACC_PCT
           - python ./examples/beautiful_mnist.py
+          # run again with high DEBUG value; exercises different paths, e.g. needs capstone
+          - if: unix
+            then:
+              - export STEPS=2
+              - export DEBUG=10
+              - unset TARGET_EVAL_ACC_PCT
+            else:
+              - set "SETPS=2"
+              - set "DEBUG=10"
+              - set "TARGET_EVAL_ACC_PCT="
+          - if: not aarch64
+            then:
+              - python ./examples/beautiful_mnist.py
 
   - package:
       name: tinygrad-tests

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -39,6 +39,8 @@ outputs:
           then:
             - mkdir -p $SP_DIR/tinygrad/extra/disassemblers/applegpu
             - cp -R ./tinygrad/extra/disassemblers/applegpu/* $SP_DIR/tinygrad/extra/disassemblers/applegpu
+            - cd $SP_DIR/tinygrad/extra/disassemblers/applegpu/compiler_explorer_tools
+            - make
     requirements:
       build:
         - if: build_platform != host_platform
@@ -51,6 +53,13 @@ outputs:
             - ${{ stdlib("c") }}
             - ${{ compiler("cxx") }}
             - ${{ compiler("cuda") }}
+        - if: osx
+          then:
+            - make
+            # for bare clang/clang++ symlinks, see
+            # https://github.com/dougallj/applegpu/blob/main/compiler_explorer_tools/Makefile
+            - clang
+            - clangxx
       host:
         - python
         - pip
@@ -69,12 +78,6 @@ outputs:
             - if: linux
               then:
                 - triton
-        - if: osx
-          then:
-            # DEBUG code builds applegpu submodule; see
-            # https://github.com/tinygrad/tinygrad/blob/v0.11.0/tinygrad/runtime/ops_metal.py#L147
-            # https://github.com/dougallj/applegpu/blob/797862eea0cee1f1/compiler_explorer.py#L22
-            - make
     tests:
       - python:
           imports:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -29,10 +29,10 @@ outputs:
       script: python -m pip install . -vv
     requirements:
       build:
-        - if: build_platform != target_platform
+        - if: build_platform != host_platform
           then:
             - python
-            - cross-python_${{ target_platform }}
+            - cross-python_${{ host_platform }}
         # this is just here so smithy creates separate jobs for the CUDA variants
         - if: cuda_compiler_version != "None"
           then:
@@ -47,13 +47,13 @@ outputs:
         - python
         - capstone
         - llvmdev
-        - clangxx_${{ target_platform }}
+        - clangxx_${{ host_platform }}
         # ensure `bin/clang` symlink is present
         - clang
         - if: cuda_compiler_version != "None"
           then:
             - __cuda
-            - cuda-nvcc_${{ target_platform }}
+            - cuda-nvcc_${{ host_platform }}
             - if: linux
               then:
                 - triton
@@ -200,7 +200,7 @@ outputs:
                 - 'tests_to_skip += " or TestGC or test_gc"'
 
             # test suite in emulation on aarch is super slow, skip it there
-            - if: unix and build_platform == target_platform
+            - if: unix and build_platform == host_platform
               then:
                 - 'sys.exit(pytest.main(["-v", "test/", "-k", f"not ({tests_to_skip})", "--durations=50"]))'
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -62,6 +62,12 @@ outputs:
             - if: linux
               then:
                 - triton
+        - if: osx
+          then:
+            # DEBUG code builds applegpu submodule; see
+            # https://github.com/tinygrad/tinygrad/blob/v0.11.0/tinygrad/runtime/ops_metal.py#L147
+            # https://github.com/dougallj/applegpu/blob/797862eea0cee1f1/compiler_explorer.py#L22
+            - make
     tests:
       - python:
           imports:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -9,14 +9,19 @@ recipe:
   version: ${{ version }}
 
 source:
-  url: https://github.com/tinygrad/tinygrad/archive/refs/tags/v${{ version }}.tar.gz
-  sha256: e5e7b0f2319a8cc8e5de14dbc6ee91a403efd2414681b874b526a8b39d7fa86f
-  patches:
-    - patches/0001-point-to-our-own-llvmdev.patch
-    # backport https://github.com/tinygrad/tinygrad/pull/12470 to make tests runnable out-of-tree
-    - patches/0002-move-frontend-dir-to-nn-pr-12470.patch
-    # see more clearly what's happening in mnist test
-    - patches/0003-update-accuracy-for-every-step-in-beautiful_mnist.py.patch
+  - url: https://github.com/tinygrad/tinygrad/archive/refs/tags/v${{ version }}.tar.gz
+    sha256: e5e7b0f2319a8cc8e5de14dbc6ee91a403efd2414681b874b526a8b39d7fa86f
+    patches:
+      - patches/0001-point-to-our-own-llvmdev.patch
+      # backport https://github.com/tinygrad/tinygrad/pull/12470 to make tests runnable out-of-tree
+      - patches/0002-move-frontend-dir-to-nn-pr-12470.patch
+      # see more clearly what's happening in mnist test
+      - patches/0003-update-accuracy-for-every-step-in-beautiful_mnist.py.patch
+  - if: osx
+    then:
+      - target_directory: tinygrad/extra/disassemblers/applegpu
+        git: https://github.com/dougallj/applegpu
+        rev: "797862eea0cee1f1eba74be3d0d02be4b3d2bd0d"
 
 build:
   number: ${{ build_number }}
@@ -212,8 +217,10 @@ about:
 
     Due to its extreme simplicity, it aims to be the easiest framework to add new accelerators to,
     with support for both inference and training. If XLA is CISC, tinygrad is RISC.
-  license: MIT
-  license_file: LICENSE
+  license: MIT AND BSD-3-Clause
+  license_file:
+    - LICENSE
+    - applegpu_LICENSE
   documentation: https://docs.tinygrad.org/
   repository: https://github.com/tinygrad/tinygrad
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -35,7 +35,7 @@ outputs:
     build:
       script:
         - python -m pip install . -vv
-        - if: osx
+        - if: false
           then:
             - mkdir -p $SP_DIR/tinygrad/extra/disassemblers/applegpu
             - cp -R ./tinygrad/extra/disassemblers/applegpu/* $SP_DIR/tinygrad/extra/disassemblers/applegpu

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -45,6 +45,7 @@ outputs:
         - setuptools
       run:
         - python
+        - capstone
         - llvmdev
         - clangxx_${{ target_platform }}
         # ensure `bin/clang` symlink is present
@@ -115,9 +116,6 @@ outputs:
             - blobfile
             - boto3
             - bottle
-            - if: x86_64
-              then:
-                - capstone
             # https://github.com/conda-forge/staged-recipes/issues/29179
             # - ggml-python
             - if: unix

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -183,10 +183,6 @@ outputs:
             else:
               - set "STEPS=25"
               - set "TARGET_EVAL_ACC_PCT=90"
-              # remove extraneous clang's in image, c.f.
-              # https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/408
-              - rmdir /s /q "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm"
-              - rmdir /s /q "C:\Program Files\LLVM"
           - if: aarch64
             then:
               # reduce number of steps in emulation


### PR DESCRIPTION
Some fixes on top of #6, now that https://github.com/conda-forge/capstone-feedstock/pull/32 is in